### PR TITLE
Make separate components optional

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -45,8 +45,10 @@ _.config.yml
 create-pwa.sketch
 
 # Tests
+favicons
 icons
 launch-screens
+config.xml
+*.appcache
 manifest.json
 service-worker.js
-*.appcache

--- a/README.md
+++ b/README.md
@@ -440,6 +440,8 @@ const appIcon = require('fs').resolve(__dirname, './your_icon.png');
 setIcons(appIcon);
 ```
 
+**The generated icons are located in the `/icons` folder.**
+
 3. To create only the launch screens:
 
 ```javascript
@@ -448,6 +450,8 @@ const launchScreen = require('fs').resolve(__dirname, './your_launch_screen.png'
 
 setLaunchScreens(launchScreen);
 ```
+
+**The generated files are located in the `/launch-screens` folder.**
 
 4. To create only manifest file:
 
@@ -460,7 +464,18 @@ setManifest(appName);
 
 **The generated `manifest.json` file contains references to the application icons. You must have these already generated otherwise you must edit your `manifest.json` file and remove them.**
 
-5. To create only service worker file:
+5. To create only favicon files:
+
+```javascript
+const { setFavicons } = require('create-pwa');
+const appIcon = require('fs').resolve(__dirname, './your_icon.png');
+
+setFavicons(appIcon);
+```
+
+**The generated files are located in the `/favicons` folder.**
+
+6. To create only service worker file:
 
 ```javascript
 const { setServiceWorker } = require('create-pwa');
@@ -470,21 +485,6 @@ setServiceWorker(appName);
 ```
 
 **The generated `service-worker.js` file contains references to the application icons and application launch screens. You must have these already generated otherwise you must edit your `service-worker.js` file and remove them.**
-
-6. To create all files:
-
-```javascript
-const createPWA = require('create-pwa');
-const icon = require('fs').resolve(__dirname, './your_icon.png');
-const launch = require('fs').resolve(__dirname, './your_launch_screen.png');
-
-createPWA({
-	icon,
-	launch
-});
-```
-
-**This command assumes that you have a `package.json` file in the folder you run the command from and this `package.json` file contains a non-empty `name` member.**
 
 ## LICENSE
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
 	"name": "create-pwa",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "Easily create a progressive web app",
 	"scripts": {
+		"pwa": "src/index.js --icon=\"./icon.png\" --launch=\"./launch.png\" --icons=false --app-cache=false --manifest=false --favicons=false --service-worker=false --launch-screens=false",
 		"test": "tape test.js"
 	},
 	"bin": {

--- a/src/index.js
+++ b/src/index.js
@@ -7,9 +7,50 @@ const { resolve, sep } = require('path');
 const { existsSync, writeFileSync, mkdirSync } = require('fs');
 
 /**
+ * Default options
+ */
+const DEFAULTS = {
+	icon: './icon.png',
+	launch: './launch.png'
+};
+
+/**
  * External dependencies
  */
-const argv = require('yargs').argv;
+const argv = require('yargs').options({
+	icon: {
+		default: DEFAULTS.icon,
+		type: 'string'
+	},
+	launch: {
+		default: DEFAULTS.launch,
+		type: 'string'
+	},
+	icons: {
+		default: true,
+		type: 'boolean'
+	},
+	manifest: {
+		default: true,
+		type: 'boolean'
+	},
+	appCache: {
+		default: true,
+		type: 'boolean'
+	},
+	favicons: {
+		default: true,
+		type: 'boolean'
+	},
+	serviceWorker: {
+		default: true,
+		type: 'boolean'
+	},
+	launchScreens: {
+		default: true,
+		type: 'boolean'
+	}
+}).argv;
 
 /**
  * Internal dependencies
@@ -26,14 +67,6 @@ const serviceWorkerTemplate = require('./sw');
  * Get caller's folder
  */
 const pwd = process.env.PWD;
-
-/**
- * Default options
- */
-const DEFAULTS = {
-	icon: './icon.png',
-	launch: './launch.png'
-};
 
 /**
  * Get application's name
@@ -122,22 +155,40 @@ const setFavicons = icon => generateImages(icon, 'favicons', generateFavicons);
  * Create all PWA required files
  * @param {Object} => { icon: File, launch: File}
  */
-const create = (options = DEFAULTS) => {
+const create = () => {
 	const name = getAppName();
 
-	let { icon, launch } = options;
+	const { icon, launch, icons, manifest, favicons, appCache, serviceWorker, launchScreens } = argv;
+	const iconToUse = icon || DEFAULTS.icon;
+	const launchToUse = launch || DEFAULTS.launch;
 
-	icon = argv.icon || icon;
-	launch = argv.launch || launch;
+	if (icons) {
+		setIcons(iconToUse);
+	}
 
-	setIcons(icon);
-	setAppCache(name);
-	setManifest(name);
-	setFavicons(icon);
-	setMsTileConfig();
-	setServiceWorker(name);
-	setLaunchScreens(launch);
+	if (manifest) {
+		setManifest(name);
+	}
+
+	if (appCache) {
+		setAppCache(name);
+	}
+
+	if (favicons) {
+		setFavicons(iconToUse);
+		setMsTileConfig();
+	}
+
+	if (serviceWorker) {
+		setServiceWorker(name);
+	}
+
+	if (launchScreens) {
+		setLaunchScreens(launchToUse);
+	}
 };
+
+create();
 
 module.exports = create;
 module.exports.setIcons = setIcons;


### PR DESCRIPTION
This PR introduces several new CLI arguments which allow separate components to be skipped.
For example one might not need to create an `.appcache` file or a Service Worker file.