### PR TITLE
Fix current working directory

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ const serviceWorkerTemplate = require('./sw');
 /**
  * Get caller's folder
  */
-const pwd = process.env.PWD;
+const pwd = process.cwd();
 
 /**
  * Get application's name


### PR DESCRIPTION
Fix current working directory instead of relying on possibly missing environment variables.
On Windows, using NVM and node v16.14.0, the environment variable is missing.